### PR TITLE
Fix sign-up API result shape

### DIFF
--- a/apps/ned/src/app/(sign-in)/page.tsx
+++ b/apps/ned/src/app/(sign-in)/page.tsx
@@ -64,7 +64,7 @@ export default function SignIn() {
     const response = await signInWithGoogle()
 
     if (!response.error) {
-      await registerUserOnBackend(response.data)
+      await registerUserOnBackend(response.data.user)
     } else {
       setErrorMessage(
         response.error.details || 'Falha ao fazer login com o Google.'
@@ -80,7 +80,7 @@ export default function SignIn() {
 
     const response = await signInWithEmailAndPassword(email, password)
     if (!response.error) {
-      await registerUserOnBackend(response.data)
+      await registerUserOnBackend(response.data.user)
     } else {
       setErrorMessage(
         response.error.code === 'auth/wrong-password'

--- a/apps/ned/src/app/register/page.tsx
+++ b/apps/ned/src/app/register/page.tsx
@@ -63,8 +63,8 @@ export default function Register() {
 
     const response = await signUpWithGoogle()
 
-    if (response.error === null) {
-      await registerUserOnBackend(response.data)
+    if (!response.error) {
+      await registerUserOnBackend(response.data.user)
     } else {
       setErrorMessage(
         response.error.details || 'Falha ao se cadastrar com o Google.'
@@ -80,8 +80,8 @@ export default function Register() {
 
     const response = await signUpWithEmailAndPassword(email, password)
 
-    if (response.error === null) {
-      await registerUserOnBackend(response.data)
+    if (!response.error) {
+      await registerUserOnBackend(response.data.user)
     } else {
       setErrorMessage(
         response.error.code === 'auth/email-already-in-use'

--- a/packages/auth/src/firebase/auth/signup.ts
+++ b/packages/auth/src/firebase/auth/signup.ts
@@ -2,43 +2,49 @@ import {
   createUserWithEmailAndPassword,
   GoogleAuthProvider,
   signInWithPopup,
-} from "firebase/auth";
+} from 'firebase/auth'
 
-import { auth } from "@/firebase/client";
+import { auth } from '@/firebase/client'
 
 export async function signUpWithEmailAndPassword(
   email: string,
-  password: string,
+  password: string
 ) {
   try {
     const userCredential = await createUserWithEmailAndPassword(
       auth,
       email,
-      password,
-    );
-    const user = userCredential.user;
+      password
+    )
+    const user = userCredential.user
 
-    return { success: true, user };
+    return {
+      success: true,
+      data: { user },
+    }
   } catch (error) {
-    console.error("Error signup:", (error as Error).message);
+    console.error('Error signup:', (error as Error).message)
     return {
       success: false,
       error:
-        (error as Error).message || "Erro desconhecido ao registrar o usuário.",
-    };
+        (error as Error).message || 'Erro desconhecido ao registrar o usuário.',
+    }
   }
 }
 
 export async function signUpWithGoogle() {
-  const provider = new GoogleAuthProvider();
+  const provider = new GoogleAuthProvider()
 
   try {
-    const result = await signInWithPopup(auth, provider);
-    const user = result.user;
+    const result = await signInWithPopup(auth, provider)
+    const user = result.user
 
-    return { success: true, user };
+    return {
+      success: true,
+      data: { user },
+    }
   } catch (error) {
-    console.error("Error signup:", (error as Error).message);
-    return { success: false, error: (error as Error).message };
+    console.error('Error signup:', (error as Error).message)
+    return { success: false, error: (error as Error).message }
   }
 }


### PR DESCRIPTION
## Summary
- normalize responses for `signUpWithEmailAndPassword` and `signUpWithGoogle`
- fix registration/signin pages to pass `user` correctly to backend

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_683f3db9f24c832398e0c5dc28ca0ed2